### PR TITLE
protocol: fix wrongly removed header

### DIFF
--- a/documentation/_posts/2013-07-09-protocol.md
+++ b/documentation/_posts/2013-07-09-protocol.md
@@ -323,6 +323,12 @@ Change a group's metadata
 * `metadata`: structure of key-value pairs for group metadata
 * `graph`: graph the action targets
 
+<a id="component"></a>
+
+## Component protocol
+
+Protocol for handling the component registry.
+
 ### `list`
 
 Request a list of currently available components. Will be responded with a set of `component` messages.


### PR DESCRIPTION
I screwed up when removing the list commands :(
