### PR TITLE
Wrong variable used for outport send

### DIFF
--- a/documentation/_posts/2013-07-12-components.md
+++ b/documentation/_posts/2013-07-12-components.md
@@ -34,7 +34,7 @@ exports.getComponent = ->
       when 'data'
         # Forward data when we receive it.
         # Note: send() will connect automatically if needed
-        component.outPorts.out.send data
+        component.outPorts.out.send payload
       when 'disconnect'
         # Disconnect output port when input port disconnects
         component.outPorts.out.disconnect()


### PR DESCRIPTION
We should be using the `payload` variable in the outport send, not the undefined variable `data`